### PR TITLE
Misc: Add a LoggedCommand wrapper

### DIFF
--- a/src/checkup.rs
+++ b/src/checkup.rs
@@ -1,24 +1,18 @@
-use std::process::Command;
+use crate::logged_command::LoggedCommand;
 
 // Command to run polkadot-dev format, flint and version --check altogether
 pub fn run_checkup(sub_matches: &clap::ArgMatches) {
     // Run `polkadot-dev format`
-    let status = Command::new("polkadot-dev")
+    LoggedCommand::new("polkadot-dev")
         .arg("format")
         .status()
         .expect("Failed to execute `polkadot-dev format`");
-    if !status.success() {
-        eprintln!("`polkadot-dev format` failed");
-    }
 
     // Run `polkadot-dev flint`
-    let status = Command::new("polkadot-dev")
+    LoggedCommand::new("polkadot-dev")
         .arg("flint")
         .status()
         .expect("Failed to execute `polkadot-dev flint`");
-    if !status.success() {
-        eprintln!("`polkadot-dev flint` failed");
-    }
 
     let version = sub_matches.get_one::<String>("version").map(|s| s.as_str());
     if !version.is_some() {
@@ -26,16 +20,13 @@ pub fn run_checkup(sub_matches: &clap::ArgMatches) {
         return;
     }
     // Run `polkadot-dev version --check`
-    let status = Command::new("polkadot-dev")
+    LoggedCommand::new("polkadot-dev")
         .arg("version")
         .arg("-v")
         .arg(version.unwrap())
         .arg("--check")
         .status()
         .expect("Failed to execute `polkadot-dev version --check`");
-    if !status.success() {
-        eprintln!("`polkadot-dev version --check` failed");
-    }
 
     println!("Code formatting complete, feature lint checks passed, and version consistency verified! 😉");
 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,7 +1,7 @@
-use std::process::Command;
+use crate::logged_command::LoggedCommand;
 
 pub fn run_format(sub_matches: &clap::ArgMatches) {
-    let mut cmd = Command::new("cargo");
+    let mut cmd = LoggedCommand::new("cargo");
 
     cmd.arg("+nightly").arg("fmt");
 

--- a/src/install.rs
+++ b/src/install.rs
@@ -1,9 +1,10 @@
-use std::process::Command;
+
+use crate::logged_command::LoggedCommand;
 
 pub fn run_install() {
     let url = "https://raw.githubusercontent.com/paritytech/polkadot-sdk/refs/heads/master/scripts/getting-started.sh";
 
-    Command::new("bash")
+    LoggedCommand::new("bash")
         .arg("-c")
         .arg(format!("curl {} | bash", url))
         .status()

--- a/src/logged_command.rs
+++ b/src/logged_command.rs
@@ -1,0 +1,44 @@
+use std::process::Command;
+use std::ffi::OsStr;
+
+pub struct LoggedCommand {
+    inner: Command,
+}
+
+impl LoggedCommand {
+    pub fn new(command: &str) -> Self {
+        Self {
+            inner: Command::new(command),
+        }
+    }
+
+    pub fn arg<S: AsRef<OsStr>>(&mut self, arg: S)-> &mut Self {
+        self.inner.arg(arg.as_ref());
+        self
+    }
+
+    pub fn status(&mut self) -> std::io::Result<()> {
+        // Format the command to print without quotes
+        let full_command = format!(
+            "{} {}",
+            self.inner.get_program().to_string_lossy(),
+            self.inner.get_args().map(|arg| arg.to_string_lossy()).collect::<Vec<_>>().join(" ")
+        );
+        println!("[INFO] Running command: {}", full_command);
+
+        // Execute the command
+        match self.inner.status() {
+            Ok(status) => {
+                if status.success() {
+                    println!("[INFO] Command executed successfully.");
+                } else {
+                    eprintln!("[WARN] Command exited with status: {}", status);
+                }
+            }
+            Err(e) => {
+                eprintln!("[ERROR] Failed to execute command: {}", e);
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,12 +5,14 @@ mod install;
 mod prdoc;
 mod psvm;
 mod checkup;
+mod logged_command;
 
 use clap::{Arg, Command};
 
 fn main() {
     let cmd = Command::new("polkadot-dev")
         .bin_name("polkadot-dev")
+        .visible_alias("polkadot-dev-cli")
         .version("1.0")
         .about(
             "CLI tool for Polkadot developers bundling linting, formatting, and version management",

--- a/src/prdoc.rs
+++ b/src/prdoc.rs
@@ -1,3 +1,4 @@
+use crate::logged_command::LoggedCommand;
 use std::process::Command;
 
 pub fn handle_prdoc_command(sub_matches: &clap::ArgMatches) {
@@ -11,7 +12,7 @@ pub fn handle_prdoc_command(sub_matches: &clap::ArgMatches) {
         install_prdoc().unwrap();
     }
 
-    let mut cmd = Command::new("prdoc");
+    let mut cmd = LoggedCommand::new("prdoc");
 
     if let Some(config) = config {
         cmd.arg("--config").arg(config);
@@ -36,7 +37,7 @@ pub fn handle_prdoc_command(sub_matches: &clap::ArgMatches) {
     }
 }
 
-fn handle_generate(cmd: &mut Command, generate_matches: &clap::ArgMatches) {
+fn handle_generate(cmd: &mut LoggedCommand, generate_matches: &clap::ArgMatches) {
     cmd.arg("generate");
 
     let number = generate_matches
@@ -59,7 +60,7 @@ fn handle_generate(cmd: &mut Command, generate_matches: &clap::ArgMatches) {
     }
 }
 
-fn handle_check(cmd: &mut Command, check_matches: &clap::ArgMatches) {
+fn handle_check(cmd: &mut LoggedCommand, check_matches: &clap::ArgMatches) {
     cmd.arg("check");
 
     let file = check_matches.get_one::<String>("file");
@@ -85,7 +86,7 @@ fn handle_check(cmd: &mut Command, check_matches: &clap::ArgMatches) {
     }
 }
 
-fn handle_scan(cmd: &mut Command, scan_matches: &clap::ArgMatches) {
+fn handle_scan(cmd: &mut LoggedCommand, scan_matches: &clap::ArgMatches) {
     cmd.arg("scan");
 
     let all = scan_matches.get_flag("all");
@@ -103,7 +104,7 @@ fn handle_scan(cmd: &mut Command, scan_matches: &clap::ArgMatches) {
     }
 }
 
-fn handle_load(cmd: &mut Command, load_matches: &clap::ArgMatches) {
+fn handle_load(cmd: &mut LoggedCommand, load_matches: &clap::ArgMatches) {
     cmd.arg("load");
 
     let file = load_matches.get_one::<String>("file");

--- a/src/psvm.rs
+++ b/src/psvm.rs
@@ -1,3 +1,4 @@
+use crate::logged_command::LoggedCommand;
 use std::io::{self};
 use std::process::Command;
 
@@ -13,7 +14,7 @@ pub fn handle_version_command(sub_matches: &clap::ArgMatches) {
     }
 
     // Prepare `psvm` command
-    let mut cmd = Command::new("psvm");
+    let mut cmd = LoggedCommand::new("psvm");
 
     // Add optional arguments to the command
     let list = sub_matches.get_flag("list");
@@ -55,13 +56,10 @@ pub fn handle_version_command(sub_matches: &clap::ArgMatches) {
 
 // Helper method to install psvm
 fn install_psvm() -> io::Result<()> {
-    let status = Command::new("cargo").arg("install").arg("psvm").status()?;
-
-    if status.success() {
-        println!("psvm installed successfully.");
-    } else {
-        eprintln!("Failed to install psvm.");
-    }
+    LoggedCommand::new("cargo")
+        .arg("install")
+        .arg("psvm")
+        .status()?;
 
     Ok(())
 }


### PR DESCRIPTION
- Adds a LoggedCommand wrapper around Command. This would print the behind the scenes steps while any command is being executed, keeping the user informed.


Example:


```bash

❯ polkadot-dev checkup
[INFO] Running command: polkadot-dev format
[INFO] Running command: cargo +nightly fmt
[INFO] Command executed successfully.
[INFO] Command executed successfully.
[INFO] Running command: polkadot-dev flint
[INFO] Running command: zepter run
[INFO] Running workflow 'default'
[INFO] 1/2 lint propagate-feature
[INFO] 2/2 lint propagate-feature
[INFO] Command executed successfully.
[INFO] Command executed successfully.
Version is required to run `polkadot-dev version --check`, skipping. Format and flint checks passed.

```

- `polkadot-dev` without any sub-commands now shows a friendly greeting rather than throwing an error :)

```bash

> polkadot-dev

Welcome to Polkadot-Dev CLI!

Polkadot unites the world's innovators and changemakers, building and using the most transformative apps and blockchains.

This tool bundles useful commands for Polkadot developers, including:
- Linting
- Formatting
- Version management

To get started with the polkadot-dev CLI try running `polkadot-dev help`.

Happy hacking! 🚀
```


Closes: #7 